### PR TITLE
Eliminate compiler warnings

### DIFF
--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons.c
@@ -628,7 +628,7 @@ char *realcons_simh_get_cmd(realcons_t *_this)
 		// rp now on first char after \n
 		wp = _this->simh_cmd_buffer;
 		// shift folowing lines to start of bufer (if any)
-		while (*wp++ = *rp++)
+		while ((*wp++ = *rp++))
 			;
 	}
 	return buffer;
@@ -650,7 +650,7 @@ char realcons_simh_getc_cmd(realcons_t *_this)
 	// shift buffer content
 	wp = _this->simh_cmd_buffer;
 	rp = wp + 1;
-	while (*wp++ = *rp++) ;
+	while ((*wp++ = *rp++)) ;
 	return result ;
 }
 

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons.c
@@ -137,7 +137,7 @@ void realcons_init(realcons_t *_this)
 	int i;
 
 	// clear all data, including the interface
-	memset(_this, 0, sizeof(_this));
+	memset(_this, 0, sizeof(*_this));
 
 	strcpy(_this->application_server_hostname, "localhost");
 	_this->console_logic_name[0] = '\0';

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_20.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_20.c
@@ -415,9 +415,9 @@ void realcons_console_pdp11_20_interface_connect(realcons_console_logic_pdp11_20
         // oder gleich "&(_switch_HALT->value)?"
         _this->cpusignal_instruction_register = &realcons_IR;
         _this->cpusignal_PSW = &realcons_PSW;
-        _this->cpusignal_R0 = &(R[0]); // R: global of pdp11_cpu.c
+        _this->cpusignal_R0 = (t_value*)&(R[0]); // R: global of pdp11_cpu.c
         _this->cpusignal_PC = &saved_PC; // R[7] not valid in console mode
-        _this->cpusignal_switch_register = &SR; // see pdp11_cpumod.SR_rd()
+        _this->cpusignal_switch_register = (t_value*)&SR; // see pdp11_cpumod.SR_rd()
     }
 
     /*** link handler to cpu/device events ***/

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_40.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_40.c
@@ -380,10 +380,10 @@ void realcons_console_pdp11_40_interface_connect(realcons_console_logic_pdp11_40
 		_this->cpusignal_instruction_register = &realcons_IR;
 		_this->cpusignal_PSW = &realcons_PSW;
 		_this->cpusignal_bus_ID_mode = &realcons_bus_ID_mode;
-		_this->cpusignal_cpu_mode = &cm; // MD_SUP,MD_
-		_this->cpusignal_R0 = &(R[0]); // R: global of pdp11_cpu.c
+		_this->cpusignal_cpu_mode = (t_value*)&cm; // MD_SUP,MD_
+		_this->cpusignal_R0 = (t_value*)&(R[0]); // R: global of pdp11_cpu.c
 		_this->cpusignal_PC = &saved_PC ; // R[7] not valid in console mode
-		_this->cpusignal_switch_register = &SR; // see pdp11_cpumod.SR_rd()
+		_this->cpusignal_switch_register = (t_value*)&SR; // see pdp11_cpumod.SR_rd()
 	}
 
 	/*** link handler to cpu/device events ***/

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_70.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp11_70.c
@@ -554,13 +554,13 @@ void realcons_console_pdp11_70_interface_connect(realcons_console_logic_pdp11_70
         _this->cpusignal_instruction_register = &realcons_IR;
         _this->cpusignal_PSW = &realcons_PSW;
         _this->cpusignal_bus_ID_mode = &realcons_bus_ID_mode;
-        _this->cpusignal_cpu_mode = &cm; // MD_SUP,MD_
+        _this->cpusignal_cpu_mode = (t_value*)&cm; // MD_SUP,MD_
         _this->cpusignal_MMR0 = &MMR0; // MMU register 17 777 572
         _this->cpusignal_MMR3 = &MMR3; // MMU register 17 772 516
-        _this->cpusignal_R0 = &(R[0]); // R: global of pdp11_cpu.c. "Working Register Set"!
+        _this->cpusignal_R0 = (t_value*)&(R[0]); // R: global of pdp11_cpu.c. "Working Register Set"!
         _this->cpusignal_PC = &saved_PC; // R[7] not valid in console mode
-        _this->cpusignal_switch_register = &SR; // see pdp11_cpumod.SR_rd()
-        _this->cpusignal_display_register = &DR;
+        _this->cpusignal_switch_register = (t_value*)&SR; // see pdp11_cpumod.SR_rd()
+        _this->cpusignal_display_register = (t_value*)&DR;
     }
 
     /*** link handler to cpu/device events ***/

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_simh.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_simh.c
@@ -207,7 +207,7 @@ t_stat realcons_simh_show_hostname(FILE *st, DEVICE *dunused, UNIT *uunused, int
 {
 	if (cptr && (*cptr != 0))
 		return SCPE_2MARG;
-	if (!cpu_realcons->application_server_hostname)
+	if (!cpu_realcons->application_server_hostname[0])
 		fprintf(st, "no host");
 	else
 		fprintf(st, "host=\"%s\"", cpu_realcons->application_server_hostname);
@@ -219,7 +219,7 @@ t_stat realcons_simh_show_panelname(FILE *st, DEVICE *dunused, UNIT *uunused, in
 {
 	if (cptr && (*cptr != 0))
 		return SCPE_2MARG;
-	if (!cpu_realcons->application_panel_name)
+	if (!cpu_realcons->application_panel_name[0])
 		fprintf(st, "host panel not set");
 	else
 		fprintf(st, "host panel=\"%s\"", cpu_realcons->application_panel_name);

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_simh.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_simh.c
@@ -80,10 +80,10 @@ t_stat sim_set_realcons(int32 flag, CONST char *cptr)
 		return SCPE_2FARG;
 	while (*cptr != 0) { /* do all mods */
 		cptr = get_glyph_nc(cptr, gbuf, ','); /* get modifier */
-		if (cvptr = strchr(gbuf, '='))
+		if ((cvptr = strchr(gbuf, '=')))
 			*cvptr++ = 0; /* = value? */
 		get_glyph(gbuf, gbuf, 0); /* modifier to UC */
-		if (ctptr = find_ctab(set_realcons_tab, gbuf)) { /* match? */
+		if ((ctptr = find_ctab(set_realcons_tab, gbuf))) { /* match? */
 			r = ctptr->action(ctptr->arg, cvptr); /* do the rest */
 			if (r != SCPE_OK)
 				return r;
@@ -192,7 +192,7 @@ t_stat sim_show_realcons(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, CONST c
 	}
 	while (*cptr != 0) {
 		cptr = get_glyph(cptr, gbuf, ','); /* get modifier */
-		if (shptr = find_shtab(show_realcons_tab, gbuf)) {
+		if ((shptr = find_shtab(show_realcons_tab, gbuf))) {
 			fprintf(st, ", ");
 			shptr->action(st, dptr, uptr, shptr->arg, cptr);
 		} else

--- a/projects/02.3_simh/4.x+realcons/src/makefile
+++ b/projects/02.3_simh/4.x+realcons/src/makefile
@@ -92,14 +92,14 @@ ifneq (,$(filter $(MAKE_TARGET_ARCH),X86 X64))
     endif
   endif
   ifeq ($(MAKE_TARGET_ARCH),X86)
-  	BIN=$(SRC)/../bin-ubuntu-x86/
-  	OS_CCDEFS += -m32
+	BIN=$(SRC)/../bin-ubuntu-x86/
+	OS_CCDEFS += -m32
   else
-  	BIN=$(SRC)/../bin-ubuntu-x64/
-  	OS_CCDEFS += -m64
+	BIN=$(SRC)/../bin-ubuntu-x64/
+	OS_CCDEFS += -m64
   endif
   CC = gcc -std=c99 -U__STRICT_ANSI__  $(CC_DEFS) $(OS_CCDEFS)\
-  	-I $(SRC) $(CC_DBG_FLAGS) -UUSE_REALCONS
+	-I $(SRC) $(CC_DBG_FLAGS) -UUSE_REALCONS
 
   ifeq ($(USE_NETWORK),)
   else
@@ -141,7 +141,7 @@ ifeq ($(MAKE_TARGET_ARCH),RPI)
   OS_CCDEFS = -D_GNU_SOURCE
   LDFLAGS = -lrt -lm  -lpthread -ldl
   CC = arm-linux-gnueabihf-gcc -std=c99 -U__STRICT_ANSI__  $(CC_DEFS) $(OS_CCDEFS) \
-  	-I $(SRC) $(CC_DBG_FLAGS) -UUSE_REALCONS
+	-I $(SRC) $(CC_DBG_FLAGS) -UUSE_REALCONS
   LIBPCAP=$(SRC)/../rpi-build/libpcap.a
   NETWORK_OPT = -DUSE_NETWORK -isystem $(SYSROOTS)/usr/local/include $(LIBPCAP)
   # NETWORK_OPT = -DUSE_NETWORK -isystem $(SYSROOTS)/usr/local/include -lpcap

--- a/projects/02.3_simh/4.x+realcons/src/makefile
+++ b/projects/02.3_simh/4.x+realcons/src/makefile
@@ -85,7 +85,7 @@ ifneq (,$(filter $(MAKE_TARGET_ARCH),X86 X64))
     OS_CCDEFS = -lm -lsocket -lnsl -lrt -lpthread -D_GNU_SOURCE
   else
     ifneq (,$(findstring darwin,$(OSTYPE)))
-      OS_CCDEFS = -D_GNU_SOURCE
+      OS_CCDEFS = -D_GNU_SOURCE -Wno-comment
     else
       OS_CCDEFS = -D_GNU_SOURCE
       LDFLAGS= -lrt -lm -lpthread -ldl

--- a/projects/02.3_simh/4.x+realcons/src/scp.c
+++ b/projects/02.3_simh/4.x+realcons/src/scp.c
@@ -8492,7 +8492,8 @@ static void inject_char_to_stdin(char ch) {
 #else // Linux?
 	//int	fd = fopen("/dev/tty", "rw") ;
 	//ioctl(fd,  TIOCSTI, &ch) ;
-	ioctl(0,  TIOCSTI, &ch) ; // does not echo
+	if (ioctl(0,  TIOCSTI, &ch) < 0)  // does not echo
+	    fprintf(stderr, "ioctl(TIOCSTI) failed: %s\r\n", strerror(errno));
 #endif
 }
 

--- a/projects/07.0_blinkenlight_api/blinkenlight_api_client.c
+++ b/projects/07.0_blinkenlight_api/blinkenlight_api_client.c
@@ -210,7 +210,7 @@ blinkenlight_api_status_t blinkenlight_api_client_get_controls(blinkenlight_api_
 			assert(c->index == i_control);
 			// server lists == client lists
 			strcpy(c->name, result_control->control.name);
-			c->type = result_control->control.type;
+			c->type = (blinkenlight_control_type_t)result_control->control.type;
 			c->is_input = result_control->control.is_input;
 			c->radix = result_control->control.radix;
 			c->value_bitlen = result_control->control.value_bitlen;


### PR DESCRIPTION
Most of these commits were made to address warnings from the clang compiler on Mac OS, two of which were actually bugs, and a warning from emacs about makefile whitespace.  In addition, 8259fd7 adds an error message that would have saved me a bunch of debugging time if it had been present.