### PR TITLE
PDP-8i Add state tracking for step counter lights.

### DIFF
--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.c
@@ -260,6 +260,7 @@ void realcons_console_pdp8i_interface_connect(realcons_console_logic_pdp8i_t *_t
 		extern int32 saved_MQ; 									/* saved MQ */
 		extern int32 saved_PC; 									/* saved IF'PC */
 		extern int32 saved_DF; 									/* saved Data Field */
+		extern int32 SC; 										/* Step counter */
 
 		extern int32 realcons_instruction_decode; // bit mask for decoded instruction, see REALCONS_PDP8I_INSTRUCTION_DECODE_*
 		extern int32 realcons_majorstate_curinstr; // all states of current instruction
@@ -283,6 +284,7 @@ void realcons_console_pdp8i_interface_connect(realcons_console_logic_pdp8i_t *_t
 		_this->cpusignal_df = &saved_DF;
 		_this->cpusignal_link_accumulator = &saved_LAC;
 		_this->cpusignal_multiplier_quotient = &saved_MQ;
+        _this->cpusignal_step_counter = &SC;
 
 		_this->cpusignal_instruction_decode = &realcons_instruction_decode;
 		// bit mask for decoded instruction, see REALCONS_PDP8I_INSTRUCTION_DECODE_*
@@ -680,7 +682,7 @@ t_stat realcons_console_pdp8i_service(realcons_console_logic_pdp8i_t *_this)
 		//	division and holds the quotient at the conclusion.
 		_this->led_multiplier_quotient->value = SIGNAL_GET(cpusignal_multiplier_quotient);
 
-
+        _this->led_step_counter->value = SIGNAL_GET(cpusignal_step_counter);
 
 		// Major state indicators
 		{

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.c
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.c
@@ -284,7 +284,7 @@ void realcons_console_pdp8i_interface_connect(realcons_console_logic_pdp8i_t *_t
 		_this->cpusignal_df = &saved_DF;
 		_this->cpusignal_link_accumulator = &saved_LAC;
 		_this->cpusignal_multiplier_quotient = &saved_MQ;
-        _this->cpusignal_step_counter = &SC;
+		_this->cpusignal_step_counter = &SC;
 
 		_this->cpusignal_instruction_decode = &realcons_instruction_decode;
 		// bit mask for decoded instruction, see REALCONS_PDP8I_INSTRUCTION_DECODE_*
@@ -682,7 +682,7 @@ t_stat realcons_console_pdp8i_service(realcons_console_logic_pdp8i_t *_this)
 		//	division and holds the quotient at the conclusion.
 		_this->led_multiplier_quotient->value = SIGNAL_GET(cpusignal_multiplier_quotient);
 
-        _this->led_step_counter->value = SIGNAL_GET(cpusignal_step_counter);
+		_this->led_step_counter->value = SIGNAL_GET(cpusignal_step_counter);
 
 		// Major state indicators
 		{

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.h
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.h
@@ -93,6 +93,7 @@ typedef struct
 	int32	*cpusignal_df; // DF = data field
 	int32 	*cpusignal_link_accumulator ;
 	int32 	*cpusignal_multiplier_quotient ;
+    int32   *cpusignal_step_counter;
 
 
 	int32	*cpusignal_instruction_decode; // bit mask for decoded isntruction, see REALCONS_PDP8I_INSTRUCTION_DECODE_*

--- a/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.h
+++ b/projects/02.3_simh/4.x+realcons/src/REALCONS/realcons_console_pdp8i.h
@@ -93,7 +93,7 @@ typedef struct
 	int32	*cpusignal_df; // DF = data field
 	int32 	*cpusignal_link_accumulator ;
 	int32 	*cpusignal_multiplier_quotient ;
-    int32   *cpusignal_step_counter;
+	int32 	*cpusignal_step_counter;
 
 
 	int32	*cpusignal_instruction_decode; // bit mask for decoded isntruction, see REALCONS_PDP8I_INSTRUCTION_DECODE_*


### PR DESCRIPTION
After playing around with the pdp8i java panel for quite some time I noticed that I never saw the step counter lights ever light up.  this happened even when I would manually deposit something into the sc register.  

After a while I determined that simh was not actually ever signaling the panel lights to light up. 

This pull request is my solution to that problem.  

You can use the following program to exercise the SC register from inside simh (it's my first ever attempt at hand assembly on anything, let alone the PDP8.) start at zero and single step and you should see the step count lights increment with the step count register if you've applied this patch. 


0 SWAB 7431
1 SWP 7521
2 IAC 7001
3 ASC 7403
4 SWBA 7747
5 SCA CLA 7641
6 JMP 5000


sim> examine 0-6
0:      7431
1:      7521
2:      7001
3:      7403
4:      7747
5:      7641
6:      5000
sim> examine -m 0-6
0:      SWAB
1:      MQA MQL
2:      IAC
3:      ACS
4:      CLA MQA SWBA
5:      CLA SCA
6:      JMP 0